### PR TITLE
Version number management improvement.

### DIFF
--- a/protonmail-cli.py
+++ b/protonmail-cli.py
@@ -47,9 +47,22 @@ def overwrite_settings(args):
 
 
 def parse_args():
+    metadata = {}
+    with open("protonmail/metadata.py") as fh:
+        exec(fh.read(), metadata)
+
     parser = argparse.ArgumentParser(
-        description="ProtonMail CLI tool",
-        epilog="Homepage: https://github.com/dimkouv/protonmail-cli")
+        description=metadata["description"],
+        epilog="Author: {name} <{email}> {url}".format(
+            name=metadata["author_name"],
+            email=metadata["author_email"],
+            url=metadata["url"]))
+
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version="%(prog)s {version}".format(version=metadata["__version__"]))
 
     parser.add_argument(
         "--credential",

--- a/protonmail/metadata.py
+++ b/protonmail/metadata.py
@@ -1,0 +1,7 @@
+__version__ = "0.0.1"
+
+name = "protonmail"
+author_name = "dimkouv"
+author_email = "dimkouv@protonmail.com"
+description = "Command line utility for https://protonmail.com"
+url = "https://github.com/dimkouv/protonmail-cli"

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,22 @@
 import setuptools
 
+metadata = {}
+with open("protonmail/metadata.py") as fh:
+    exec(fh.read(), metadata)
+
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="protonmail",
-    version="0.0.1",
-    author="dimkouv",
-    author_email="dimkouv@protonmail.com",
-    description=" Command line utility for https://protonmail.com",
+    name=metadata["name"],
+    version=metadata["__version__"],
+    author=metadata["author_name"],
+    author_email=metadata["author_email"],
+    description=metadata["description"],
     long_description=long_description,
     license='MIT',
     long_description_content_type="text/markdown",
-    url="https://github.com/dimkouv/protonmail-cli",
+    url=metadata["url"],
     python_requires='>=3',
     install_requires=[
         "beautifulsoup4",


### PR DESCRIPTION
I saw you added a version number to the app, so I though about adding it to the command line, but didn't want to hardcode it. I looked up on how Python communities solved this problem and this is what I came up with. What do you think?

Reference: https://packaging.python.org/guides/single-sourcing-package-version/