### PR TITLE
change name bug

### DIFF
--- a/protonmail/core.py
+++ b/protonmail/core.py
@@ -212,7 +212,10 @@ class ProtonmailClient:
             variables.element_account['save_btn'])
         el.click()
         time.sleep(settings.load_wait)
-
+        #click back button
+        el = self.web_driver.find_element_by_class_name(
+            variables.element_account['back_btn'])
+        el.click()
     def send_mail(self, to, subject, message):
         """Sends email.
 

--- a/protonmail/variables.py
+++ b/protonmail/variables.py
@@ -35,7 +35,10 @@ element_account = dict(
     display_name="displayName",
 
     # save button class on account settings page
-    save_btn="identitySection-form .pm_button.primary"
+    save_btn="identitySection-form .pm_button.primary",
+   
+    #back button class to return back to main page
+    back_btn=".sidebar-btn-back"    
 )
 
 element_twofactor = dict(


### PR DESCRIPTION
We are not returning back to compose mail page. So if someone calls send_mail after change_name he was getting error. So fixing that bug to go out of the profile after changing / back to mail page