### PR TITLE
Added user folder and label capabilities

### DIFF
--- a/protonmail/core.py
+++ b/protonmail/core.py
@@ -140,12 +140,13 @@ class ProtonmailClient:
 
     def get_mails(self, page):
         """
-        Get a list of mails that are into the given page
+        Get a list of mails that are into the given page, folder, or label
 
-        :param page: One of the pages listed in variables.py > page_urls
+        :param page: One of the pages listed in variables.py > page_urls, or a user defined folder or label
         :return: a list of Mail objects
         """
-        url = variables.page_urls.get(page)
+
+        url = variables.page_urls.get(page) or self.get_folders_and_labels().get(page.lower())
         if not url:
             raise ValueError("Page doesn't exist")
 
@@ -163,9 +164,6 @@ class ProtonmailClient:
         """
         # this is valid because ProtonMail folders are case-insensitive
         folder = folder.lower()
-
-        print("Folder is {}".format(folder))
-        print("folder list is {}".format(self.get_folders()))
 
         url = self.get_folders().get(folder)
         if not url:

--- a/protonmail/variables.py
+++ b/protonmail/variables.py
@@ -1,8 +1,11 @@
 # ProtonMail web interface variables
 # Current WebClient version: v3.14.10
 
+# Base URL for the ProtonMail web interface
+base_url = "https://mail.protonmail.com"
+
 # Main URL for the login interface.
-url = "https://mail.protonmail.com/login"
+url = base_url + "/login"
 
 # Pages that contain mails and their urls
 page_urls = dict(
@@ -92,6 +95,21 @@ element_send_mail = dict(
     # CSS selector for 'as attachment' button that appears when you try
     # to add an image as attachment
     as_attachment_btn="button.pm_button.primary.composerAskEmbdded-btn-attachment"
+)
+
+element_folders_labels = dict(
+    # CSS selector for a list-item in the sidebar
+    # indicating either a folder or label
+    list_element_selector=".menuLabel-item",
+
+    # CSS selector specific to folders in the list of folders and labels
+    folder_element_selector=".fa-folder.menuLabel-icon",
+
+    # CSS selector specific to labels in the list of folders and labels
+    label_element_selector=".fa-tag.menuLabel-icon",
+
+    # CSS selector for the title in a folder or label list-item
+    list_element_title_selector=".menuLabel-title"
 )
 
 # Other variables used by protonmail-cli


### PR DESCRIPTION
Folders and labels are user defined constructs for organizing messages. In ProtonMail, emails can have multiple labels but can only reside in one folder. [more](https://protonmail.com/support/knowledge-base/creating-folders/)

In the first commit, I added the following methods:

- _get_mails_in_folder()_ to get mail items from a folder
- _get_mails_in_label()_ to get mail items from a label
- _get_folders_and_labels()_ to return a dictionary of folders and labels and their URLs, modeled off of variables.page_urls
- _get_folders()_ to return just folders
- _get_labels()_ to return just labels

In the second commit, I modified _get_mails()_ to also determine if the page parameter is a valid folder or label, using the _get_folders_and_labels()_ method.

I wasn't sure if you want the functionality included in _get_mails()_, so that's why I broke it out.