### PR TITLE
Fixed HTML Mailing

### DIFF
--- a/protonmail/core.py
+++ b/protonmail/core.py
@@ -405,12 +405,14 @@ class ProtonmailClient:
             # render as html by executing a js oneliner to alter the DOM
             self.web_driver.execute_script("""
                 document.querySelector('.angular-squire-iframe body>div').innerHTML="%s"
-            """ % (message.replace('"', '\\"')))
+            """ % (message))
+            el.send_keys()
 
         self.web_driver.switch_to.default_content()
 
         if attachments:
             upload_attachments(attachments)
+
 
         # click send
         el = self.web_driver.find_element_by_css_selector(


### PR DESCRIPTION
Previously, HTML mails couldn't be sent. Now, then can be.
The attachment problem still remains, i.e. emails can't be sent without an attachment